### PR TITLE
Fixed Errors on Timer page and Singlerecipe page

### DIFF
--- a/digitalcookbook/app/components/singlerecipeui.tsx
+++ b/digitalcookbook/app/components/singlerecipeui.tsx
@@ -99,13 +99,14 @@ export default function SingleRecipeUI({ recipe }: { recipe: Recipe }) {
 
           {/* Ingredients */}
           <div className="px-6 py-6 flex justify-left">
-            <section className="rounded-lg bg-[#dfe8d8] p-4">
+            <section className="rounded-lg bg-[#dfe8d8] p-4 w-1/3">
               <h2 className="text-center text-md font-bold tracking-wide">{t.ing}</h2>
-              <ul className="mt-3 list-disc space-y-1 pl-5 text-sm">
+              <ul className="mt-3 list-disc list-inside space-y-1 pl-5 text-sm ">
                 {recipe?.ingredientPlainText?.[lang] ? (
                   recipe.ingredientPlainText?.[lang]
+                    .replace(/\n(?![\d|¼|½|¾|O])/g, " ")
                     .split("\n")
-                    .map((line, i) => <li key={i}>{line.trim()}</li>)
+                    .map((line, i) => <li key={i} className="break-words">{line.trim()}</li>)
                 ) : (
                   <li className="text-base-content/60">No ingredients listed.</li>
                 )}

--- a/digitalcookbook/app/timer/timer.tsx
+++ b/digitalcookbook/app/timer/timer.tsx
@@ -11,7 +11,8 @@ const STRINGS = {
     seconds: "seconds",
     start: "Start",
     pause: "Pause",
-    reset: "Reset"
+    reset: "Reset",
+    remaining: "Time Remaining"
   },
   es: {
     hours: "horas",
@@ -19,7 +20,8 @@ const STRINGS = {
     seconds: "segundos",
     start: "Iniciar",
     pause: "Pausa",
-    reset: "Reiniciar"
+    reset: "Reiniciar",
+    remaining: "Tiempo Restante"
   }
 };
 
@@ -51,8 +53,11 @@ export default function Timer() {
 
   // Timer control handlers 
   const handleStart = () => {
-    const totalSeconds = inputHours * 3600 + inputMinutes * 60 + inputSeconds;
-    setSecondsLeft(totalSeconds);
+    if(secondsLeft == 0) {
+      const totalSeconds = inputHours * 3600 + inputMinutes * 60 + inputSeconds;
+      setSecondsLeft(totalSeconds);
+    }
+    
     setIsRunning(true);
   };
 
@@ -101,7 +106,7 @@ export default function Timer() {
       {/* Timer display */}
       <div className="card w-[44rem] bg-base-100 shadow-xl p-6 -mt-20">
         <div className="stat text-center">
-          <div className="stat-title text-xl md:text-2xl -mt-9">Time Remaining</div>
+          <div className="stat-title text-xl md:text-2xl -mt-9">{t.remaining}</div>
           <div className="stat-value text-8xl md:text-9xl font-bold text-gray-600">{formatTime(secondsLeft)}</div>
         </div>
       </div>
@@ -183,16 +188,6 @@ export default function Timer() {
             {t.reset}
           </button>
         </div>
-      </div>
-
-      {/* Buttons */}
-      <div className="flex gap-4">
-        {!isRunning ? (
-          <button onClick={handleStart} className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Start</button>
-        ) : (
-          <button onClick={handlePause} className="px-4 py-2 bg-yellow-500 text-white rounded hover:bg-yellow-600">Pause</button>
-        )}
-        <button onClick={handleReset} className="px-4 py-2 bg-red-500 text-white rounded hover:bg-red-600">Reset</button>
       </div>
     </div>
   );


### PR DESCRIPTION
Timer page had two sets of buttons, reset on pauses, and didnt fully translate. Now the page fully translates, pauses properly, and has only the one set of buttons.

Singlerecipe page had parts of ingredients not showing in the list properly (half the ingredient on another line) for some of the recipes. Now I have added a regex to fix this issue, however it will probably need to be looked at later.